### PR TITLE
Adicionar string vazia quando usar o bloco empty

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,8 +135,8 @@ data "aws_iam_policy_document" "resource_full_access" {
 
 data "aws_iam_policy_document" "resource" {
   count         = module.this.enabled ? 1 : 0
-  source_json   = local.principals_readonly_access_non_empty ? join("", [data.aws_iam_policy_document.resource_readonly_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
-  override_json = local.principals_full_access_non_empty ? join("", [data.aws_iam_policy_document.resource_full_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
+  source_json   = local.principals_readonly_access_non_empty ? join("", [data.aws_iam_policy_document.resource_readonly_access[0].json]) : ""
+  override_json = local.principals_full_access_non_empty ? join("", [data.aws_iam_policy_document.resource_full_access[0].json]) : ""
 }
 
 resource "aws_ecr_repository_policy" "name" {


### PR DESCRIPTION
## Descrição

Quando o código usa o data source `aws_iam_policy_document.empty`, ele está retornando um objeto, em vez de retornar vazio. Esse fix insere uma string vazia onde esse data `aws_iam_policy_document.empty` é usado.